### PR TITLE
Fix for TRANSREL-24

### DIFF
--- a/web-app/dataExportRScripts/PivotData/PivotGeneExprData.R
+++ b/web-app/dataExportRScripts/PivotData/PivotGeneExprData.R
@@ -90,8 +90,9 @@ fileName
 	colnames(finalData)[1] <- "PROBE ID"
 	
 	#Write the final data file.
-	write.matrix(finalData,fileName,sep = "\t")
-
+	#write.matrix(finalData,fileName,sep = "\t")
+    # Using write.table because write.matrix writes out trailing whitespace - see JIRA item TRANSREL-24
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
 }
 
 

--- a/web-app/dataExportRScripts/PivotData/PivotSNPCNVData.R
+++ b/web-app/dataExportRScripts/PivotData/PivotSNPCNVData.R
@@ -96,6 +96,8 @@ subjectsStr, delimiter, filesPath, platformName
   
   #Write the final data file, rename temp to something more meaningful.
   if (finalDataExists) {
-    write.matrix(finalData,paste(platformName, ".CNV", sep=""),sep = "\t")
+    # write.matrix(finalData,paste(platformName, ".CNV", sep=""),sep = "\t")
+    # Using write.table because write.matrix writes out trailing whitespace - see JIRA item TRANSREL-24
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
   }
 }


### PR DESCRIPTION
Changed R fines to write out table data for export using write.table instead of write.matrix; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24. See also companion pull request in Rmodules
