### PR TITLE
TRANSREL-21

### DIFF
--- a/web-app/js/datasetExplorer/datasetExplorer.js
+++ b/web-app/js/datasetExplorer/datasetExplorer.js
@@ -2059,6 +2059,18 @@ function runAllQueries(callback, panel) {
             panel.body.unmask();
         }
         Ext.Msg.alert('Subsets are empty', 'All subsets are empty. Please select subsets.');
+        return;
+    }
+
+    panel.body.unmask();
+    for (var i = 1; i <= GLOBAL.NumOfSubsets; i++) {
+        if (isSubsetOnlyExclude(i)) {
+            if (panel) {
+                panel.body.unmask();
+            }
+            Ext.Msg.alert('Subset is only exclude', 'Subset ' + i + ' contains only EXCLUDE caluses. Please add at least one INCLUDE clause.');
+            return;
+        }
     }
 
     // setup the number of subsets that need running

--- a/web-app/js/datasetExplorer/i2b2common.js
+++ b/web-app/js/datasetExplorer/i2b2common.js
@@ -1775,6 +1775,24 @@ function isSubsetEmpty(subset)
 	return true;
 }
 
+function isSubsetOnlyExclude(subset) {
+
+    var allExcludes = true;
+    var count = 0;
+    for(var d=1;d<=GLOBAL.NumOfQueryCriteriaGroups;d++)
+    {
+        var queryDiv=Ext.get("queryCriteriaDiv"+subset+'_'+d);
+        if (queryDiv.dom.childNodes.length>0) {
+            count++;
+            var isInclude = (queryDiv.dom.className.indexOf("queryGroupInclude") > -1);
+            if (isInclude) allExcludes = false;
+        }
+    }
+    allExcludes = (count > 0) && allExcludes;
+
+    return allExcludes;
+}
+
 function showConceptDistributionHistogram(){
 var conceptnode=selectedConcept; 
 /*var cdhwindow=Ext.getCmp('cdhwindow');


### PR DESCRIPTION
Check for the case that any of the subset-selection queries contains only EXCLUDE clauses, and in that case alert the use to add an INCLUDE clause. Any subset-selection queries must contain at least one INCLUDE clause - see method canPerforn(User, ProtectedOperation, QueryDefinition) at about line 183 in the org.transmartproject.db.accesscontrol.AccessControlChecks (in the src dir) of transmart-core-db
