### PR TITLE
Fix for TRANSREL-43

### DIFF
--- a/grails-app/services/org/transmartfoundation/status/SolrStatusService.groovy
+++ b/grails-app/services/org/transmartfoundation/status/SolrStatusService.groovy
@@ -19,7 +19,8 @@ class SolrStatusService {
 		def urlString = "http://localhost:8983/solr/"
 		def solrQuery = '*:*'
 
-		SolrClient solr = new HttpSolrClient(urlString)
+        HttpClient httpClient = HttpClientBuilder.create().build()
+		SolrClient solr = new HttpSolrClient(urlString,httpClient)
 		
 		NamedList nl = new NamedList()
 		nl.addAll(['q':solrQuery])

--- a/grails-app/services/org/transmartfoundation/status/SolrStatusService.groovy
+++ b/grails-app/services/org/transmartfoundation/status/SolrStatusService.groovy
@@ -45,6 +45,7 @@ class SolrStatusService {
 		def canConnect = reachedServer
 			
 		solr.close();
+        httpClient.close();
 		
 		def settings = [
             'url'                   : urlString,

--- a/grails-app/services/org/transmartfoundation/status/SolrStatusService.groovy
+++ b/grails-app/services/org/transmartfoundation/status/SolrStatusService.groovy
@@ -2,6 +2,8 @@ package org.transmartfoundation.status
 
 import java.util.Date
 import grails.transaction.Transactional
+import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.solr.common.SolrDocumentList
 import org.apache.solr.common.params.SolrParams
 import org.apache.solr.common.util.NamedList
@@ -19,7 +21,7 @@ class SolrStatusService {
 		def urlString = "http://localhost:8983/solr/"
 		def solrQuery = '*:*'
 
-        HttpClient httpClient = HttpClientBuilder.create().build()
+        CloseableHttpClient httpClient = HttpClientBuilder.create().build()
 		SolrClient solr = new HttpSolrClient(urlString,httpClient)
 		
 		NamedList nl = new NamedList()


### PR DESCRIPTION
Fix for error in which we were using (depricated) DefaultHtmlClient (which is the default HttpClient for HttpSolrClient); by adding an explicit client (an CloseableHttpClient, in this case) we avoid the construction of the HttpSolrClient use the default HttpClient.
