### PR TITLE
For Status panel, replaced dependency for HttpClient

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -78,7 +78,7 @@ grails.project.dependency.resolution = {
         compile 'com.google.guava:guava:14.0.1'
         compile 'net.sf.ehcache:ehcache:2.9.0'
 
-        compile 'org.apache.httpcomponents:httpclient:4.5.1'
+        compile 'org.apache.httpcomponents:httpclient:4.2.4'
         compile 'org.apache.solr:solr-solrj:5.4.1'
         compile 'org.apache.solr:solr-core:5.4.1'
 

--- a/grails-app/services/org/transmartfoundation/status/SolrStatusService.groovy
+++ b/grails-app/services/org/transmartfoundation/status/SolrStatusService.groovy
@@ -2,8 +2,9 @@ package org.transmartfoundation.status
 
 import java.util.Date
 import grails.transaction.Transactional
-import org.apache.http.impl.client.HttpClientBuilder
-import org.apache.http.impl.client.CloseableHttpClient
+//import org.apache.http.impl.client.HttpClientBuilder
+//import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.solr.common.SolrDocumentList
 import org.apache.solr.common.params.SolrParams
 import org.apache.solr.common.util.NamedList
@@ -21,7 +22,8 @@ class SolrStatusService {
 		def urlString = "http://localhost:8983/solr/"
 		def solrQuery = '*:*'
 
-        CloseableHttpClient httpClient = HttpClientBuilder.create().build()
+//        CloseableHttpClient httpClient = HttpClientBuilder.create().build()
+        DefaultHttpClient httpClient = new DefaultHttpClient()
 		SolrClient solr = new HttpSolrClient(urlString,httpClient)
 		
 		NamedList nl = new NamedList()
@@ -45,7 +47,8 @@ class SolrStatusService {
 		def canConnect = reachedServer
 			
 		solr.close();
-        httpClient.close();
+//        httpClient from DefaultHttpClient does not have .close()
+//        httpClient.close();
 		
 		def settings = [
             'url'                   : urlString,


### PR DESCRIPTION
For Status panel, replaced dependency, org.apache.httpcomponents:httpclient:4.5.1, with earlier version, org.apache.httpcomponents:httpclient:4.2.4, because version 4.5.1 was creating conflicts (with its's dependencies) with dependencies of sping security.
