### PR TITLE
Fix for TRANSREL-82

### DIFF
--- a/web-app/js/datasetExplorer/datasetExplorer.js
+++ b/web-app/js/datasetExplorer/datasetExplorer.js
@@ -2156,6 +2156,9 @@ function isSubsetQueriesChanged(referenceQueries) {
             // check if reference query is the same as the new query
             // return true if it's changed.
             retVal = referenceQueries[i] !== _newQuery ? true : false;
+        } else {
+            // referenceQueries is null or undefined
+            if (_newQuery) return true;
         }
 
         if (retVal) {


### PR DESCRIPTION
Previously, going directly from cohort selection to grid view or analysis caused an error because the cohort was not fetched. This has been fixed.
