### PR TITLE
Fix for TRANSREL-57

### DIFF
--- a/grails-app/services/I2b2HelperService.groovy
+++ b/grails-app/services/I2b2HelperService.groovy
@@ -121,12 +121,13 @@ class I2b2HelperService {
     def String getColumnNameFromKey(String concept_key) {
         String[] splits = concept_key.split("\\\\");
         String concept_name = "";
-        //if(splits.length>1)
-        //{
-        //	concept_name="...\\"+splits[splits.length-2]+"\\"+splits[splits.length-1];
-        //}
-        //else
-        concept_name = splits[splits.length - 1];
+        if(splits.length>1)
+        {
+            concept_name="...\\"+splits[splits.length-2]+"\\"+splits[splits.length-1];
+        }
+        else {
+            concept_name = splits[splits.length - 1];
+        }
         return concept_name;
     }
 


### PR DESCRIPTION
show last two elements of path as column name for grid view as opposed to the (often ambiguous) leaf node only.
