### PR TITLE
Revert "Fix for TRANSREL-57"

### DIFF
--- a/grails-app/services/I2b2HelperService.groovy
+++ b/grails-app/services/I2b2HelperService.groovy
@@ -121,13 +121,12 @@ class I2b2HelperService {
     def String getColumnNameFromKey(String concept_key) {
         String[] splits = concept_key.split("\\\\");
         String concept_name = "";
-        if(splits.length>1)
-        {
-            concept_name="...\\"+splits[splits.length-2]+"\\"+splits[splits.length-1];
-        }
-        else {
-            concept_name = splits[splits.length - 1];
-        }
+        //if(splits.length>1)
+        //{
+        //	concept_name="...\\"+splits[splits.length-2]+"\\"+splits[splits.length-1];
+        //}
+        //else
+        concept_name = splits[splits.length - 1];
         return concept_name;
     }
 


### PR DESCRIPTION
Reverts tranSMART-Foundation/transmartApp#21 - see notes on https://jira.transmartfoundation.org/browse/TRANSREL-57 - the problem was really with export, which already has a fix in place, and extending the column heading to two elements (as per pull request 21) makes the column names in grid view too long - since the full path (in gridView) is already available as a mouse-over pop-up, I am reverting this change.
