### PR TITLE
Quick fix for GWAS Upload problems: remove page

### DIFF
--- a/grails-app/views/layouts/_commonheader.gsp
+++ b/grails-app/views/layouts/_commonheader.gsp
@@ -59,7 +59,7 @@
                         <g:else><th class="menuLink"><g:link controller="GWAS">GWAS</g:link></th></g:else>
                     </g:if>
 
-                    <g:if test="${!grailsApplication.config.ui.tabs.uploadData.hide}">
+                    <g:if test="${grailsApplication.config.ui.tabs.uploadData.show}">
                         <g:if test="${'uploaddata' == app}"><th class="menuVisited">Upload GWAS</th></g:if>
                         <g:else><th class="menuLink"><g:link controller="uploadData">Upload GWAS</g:link></th></g:else>
                     </g:if>


### PR DESCRIPTION
This change removes the 'Upload GWAS' page by requiring a flag, grailsApplication.config.ui.tabs.uploadData.show, to exist and be set to true before the page will appear in the UI. Related directly to JIRA issues TRANSREL-25 and TRANSREL-49 
